### PR TITLE
Add error handling to the local mysqldump command

### DIFF
--- a/src/lib/Source.php
+++ b/src/lib/Source.php
@@ -90,8 +90,18 @@ class DBSource extends Source {
 		
 	}
 	
-	public function getStructure(){
-		return shell_exec( $this->buildCommand() );
+	public function getStructure() {
+		$output      = array();
+		$returnValue = null;
+
+		exec($this->buildCommand(), $output, $returnValue);
+		$output = implode(PHP_EOL, $output);
+
+		if($returnValue !== 0) {
+			throw new Exception("Dumping '{$this->type}' data - " . $output);
+		}
+		
+		return $output;
 	}
 	
 	protected function buildCommand(){


### PR DESCRIPTION
Errors from mysqldump were not handled, so the output could be diffed
against an empty dump with no notification to the user.

The return value of the command is checked, and if it is not 0 the
output from the command is thrown as an exception.
